### PR TITLE
feat(mgmt): detect duplicated method names

### DIFF
--- a/src/AutoRest.CSharp/Mgmt/Models/MgmtRestOperation.cs
+++ b/src/AutoRest.CSharp/Mgmt/Models/MgmtRestOperation.cs
@@ -29,7 +29,7 @@ namespace AutoRest.CSharp.Mgmt.Models
         /// We use the <see cref="OperationGroup"/> to get a fully quanlified name for this operation
         /// </summary>
         public OperationGroup OperationGroup => RestClient.OperationGroup;
-        public string OperationId => OperationGroup.Key.IsNullOrEmpty() ? Operation.Language.Default.Name : $"{OperationGroup.Key}_{Operation.Language.Default.Name}";
+        public string OperationId => BuildOperationId(OperationGroup, Operation);
         /// <summary>
         /// The name of this operation
         /// </summary>
@@ -62,6 +62,17 @@ namespace AutoRest.CSharp.Mgmt.Models
             RequestPath = requestPath;
             ContextualPath = contextualPath;
             Name = methodName;
+        }
+
+        /// <summary>
+        /// Build "operation_id" property from OperationGroup and Operation
+        /// </summary>
+        /// <param name="operationGroup"></param>
+        /// <param name="operation"></param>
+        /// <returns>Original "operation_id" property</returns>
+        public static string BuildOperationId(OperationGroup operationGroup, Operation operation)
+        {
+            return operationGroup.Key.IsNullOrEmpty() ? operation.Language.Default.Name : $"{operationGroup.Key}_{operation.Language.Default.Name}";
         }
     }
 }


### PR DESCRIPTION
1. cache generated method names when parsing code model
2. catch duplicated method names and show error message with prompt
3. refactor `Resource` to extract a static method which can build the `operation_id` from `OperationGroup` and `Operation`.

#1626

# Description
<i>Add your description here!</i>

# Checklist

To ensure a quick review and merge, please ensure:
- [ ] The PR has a understandable title and description explaining the _why_ and _what_.
- [ ] The PR is opened in draft if not ready for review yet.
   - If opened in draft, please allocate sufficient time (24 hours) after moving out of draft for review
- [ ] The branch is recent enough to not have merge conflicts upon creation.

# Ready to Land?
- [ ] Build is completely green
   - Submissions with test failures require tracking issue and approval of a CODEOWNER
- [ ] At least one +1 review by a CODEOWNER
- [ ] All -1 reviews are confirmed resolved by the reviewer 
   - Override/Marking reviews stale must be discussed with CODEOWNERS first